### PR TITLE
Dialogo de alerta padrão com um botão e mudança nas funções de dialogo de alerta

### DIFF
--- a/lib/shared/components/dialogs/default_alert_dialog.dart
+++ b/lib/shared/components/dialogs/default_alert_dialog.dart
@@ -5,25 +5,29 @@ import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/navigator.dart';
 
 class DefaultAlertDialog extends StatelessWidget {
-  const DefaultAlertDialog({Key? key, required this.title, required this.body, required this.cancelText, required this.onConfirm, required this.confirmText}) : super(key: key);
+  const DefaultAlertDialog({Key? key, required this.title, required this.body, required this.cancelText, required this.onConfirm, required this.confirmText, required this.confirmColor, required this.cancelColor}) : super(key: key);
+
   final String title;
   final String body;
   final String cancelText;
   final String confirmText;
   final VoidCallback onConfirm;
-
-  static ButtonStyle styleConfirm = ElevatedButton.styleFrom(
-    backgroundColor: kSuccessColor,
-    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)),
-  );
-
-  static ButtonStyle styleCancel = ElevatedButton.styleFrom(
-    backgroundColor: kErrorColor,
-    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)),
-  );
+  final Color confirmColor;
+  final Color cancelColor;
 
   @override
   Widget build(BuildContext context) {
+
+    ButtonStyle styleConfirm = ElevatedButton.styleFrom(
+      backgroundColor: confirmColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)),
+    );
+
+   ButtonStyle styleCancel = ElevatedButton.styleFrom(
+      backgroundColor: cancelColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)),
+    );
+
     Size size = MediaQuery.of(context).size;
     return SizedBox(
       height: size.height * 0.3,
@@ -85,6 +89,71 @@ class DefaultAlertDialog extends StatelessWidget {
                 ),
               ),
             ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class DefaultAlertDialogOneButton extends StatelessWidget {
+  const DefaultAlertDialogOneButton({Key? key, required this.title, required this.body, required this.onConfirm, required this.confirmText, required this.buttonColor}) : super(key: key);
+
+  final String title;
+  final String body;
+  final String confirmText;
+  final VoidCallback onConfirm;
+  final Color buttonColor;
+
+  @override
+  Widget build(BuildContext context) {
+
+    ButtonStyle styleConfirm = ElevatedButton.styleFrom(
+      backgroundColor: buttonColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)),
+    );
+
+    Size size = MediaQuery.of(context).size;
+    return SizedBox(
+      height: size.height * 0.3,
+      child: AlertDialog(
+        backgroundColor: Theme.of(context).cardColor,
+        insetPadding:
+        const EdgeInsets.symmetric(horizontal: 15),
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10.0)),
+        title: Center(
+          child: Text(
+            title,
+            style: kBody2,
+          ),
+        ),
+        content: Text(
+          body,
+          style: kCaption2,
+        ),
+        actions:<Widget>[
+          Align(
+            alignment: Alignment.center,
+            child: Padding(
+              padding: const EdgeInsets.only(
+                  right: 28, bottom: 4),
+              child: SizedBox(
+                width: size.width * 0.3,
+                height: size.height * 0.040,
+                child: ElevatedButton(
+                  style: styleConfirm,
+                  onPressed: onConfirm,
+                  child: Text(
+                    confirmText,
+                    style: TextStyle(
+                        color: kTextColor,
+                        fontSize: size.height * 0.018,
+                        fontWeight: FontWeight.w500),
+                  ),
+                ),
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/shared/components/dialogs/default_alert_dialog.dart
+++ b/lib/shared/components/dialogs/default_alert_dialog.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:thunderapp/components/buttons/custom_text_button.dart';
-import 'package:thunderapp/components/buttons/primary_button.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/navigator.dart';
 


### PR DESCRIPTION
Agora recebe as cores dos botões como parâmetro.

Obs: Foram 2 commits iguais por conta de um erro no meu repositório local.